### PR TITLE
[2022.12.11] 길지문

### DIFF
--- a/problems/[221206] 328. Odd Even Linked List.js
+++ b/problems/[221206] 328. Odd Even Linked List.js
@@ -12,5 +12,20 @@
  * @return {ListNode}
  */
 const oddEvenList = function(head) {
+  if (head === null) return null;
 
+  let oddTail = head;
+  const evenHead = head.next;
+  let evenTail = evenHead;
+
+  while (evenTail !== null && evenTail.next !== null) {
+      oddTail.next = evenTail.next;
+      oddTail = oddTail.next;
+      evenTail.next = oddTail.next;
+      evenTail = evenTail.next;
+  }
+
+  oddTail.next = evenHead;
+
+  return head;
 };

--- a/problems/[221208] 1710. Maximum Units on a Truck.js
+++ b/problems/[221208] 1710. Maximum Units on a Truck.js
@@ -6,17 +6,16 @@
  * @return {number}
  */
 const maximumUnits = function(boxTypes, truckSize) {
-  const sortedBoxTypes = [...boxTypes].sort((a, b) => a[1] - b[1]);
+  const sortedBoxTypes = [...boxTypes].sort((a, b) => b[1] - a[1]);
   let result = 0;
-  let remainingTruckSize = truckSize;
 
-  while (remainingTruckSize && sortedBoxTypes.length) {
-    const currentBox = sortedBoxTypes.pop();
+  for (const box of sortedBoxTypes) {
+    const boxCount = Math.min(box[0], truckSize);
 
-    if (currentBox[0] > remainingTruckSize) return result += (currentBox[1] * remainingTruckSize);
+    result += box[1] * boxCount;
+    truckSize -= boxCount;
 
-    result += (currentBox[1] * currentBox[0]);
-    remainingTruckSize -= currentBox[0];
+    if (!truckSize) break;
   }
 
   return result;

--- a/problems/[221208] 1710. Maximum Units on a Truck.js
+++ b/problems/[221208] 1710. Maximum Units on a Truck.js
@@ -5,18 +5,6 @@
  * @param {number} truckSize
  * @return {number}
  */
-const maximumUnits = function(boxTypes, truckSize) {
-  const sortedBoxTypes = [...boxTypes].sort((a, b) => b[1] - a[1]);
-  let result = 0;
+const maximumUnits = function (boxTypes, truckSize) {
 
-  for (const box of sortedBoxTypes) {
-    const boxCount = Math.min(box[0], truckSize);
-
-    result += box[1] * boxCount;
-    truckSize -= boxCount;
-
-    if (!truckSize) break;
-  }
-
-  return result;
 };

--- a/problems/[221208] 1710. Maximum Units on a Truck.js
+++ b/problems/[221208] 1710. Maximum Units on a Truck.js
@@ -6,5 +6,17 @@
  * @return {number}
  */
 const maximumUnits = function (boxTypes, truckSize) {
+  const sortedBoxTypes = [...boxTypes].sort((a, b) => b[1] - a[1]);
+  let result = 0;
 
+  for (const box of sortedBoxTypes) {
+    const boxCount = Math.min(box[0], truckSize);
+
+    result += box[1] * boxCount;
+    truckSize -= boxCount;
+
+    if (!truckSize) break;
+  }
+
+  return result;
 };

--- a/problems/[221211] 561. Array Partition.js
+++ b/problems/[221211] 561. Array Partition.js
@@ -5,5 +5,12 @@
  * @return {number}
  */
 var arrayPairSum = function(nums) {
+  const sortedNums = [...nums].sort((a, b) => a - b);
+  let result = 0;
 
+  for (let i = 0; i < sortedNums.length; i += 2) {
+      result += sortedNums[i];
+  }
+
+  return result;
 };


### PR DESCRIPTION
## 접근 및 풀이
두개씩 짝 지은 숫자들 중 작은값의 합의 최대값을 구해야하니 결국 값이 큰 숫자가 값이 작은 숫자랑 붙는걸 최대한 피해줘야 최대값이 크게 나올 수 있습니다. 결국 작은 수는 작은수들 끼리 붙어있고 큰 수는 큰 수들끼리 붙어있어야 좋으니 먼저 오름차순으로 정렬을 한 후 차례대로 두 개씩 짝지어주면 되겠다 생각했습니다.

자바 스크립트 내장 메서드 `array.sort()` 를 이용하여 작은 수부터 차례대로 나열 하였고, 우리가 실질적으로 필요한 값은 `index` 가 0, 2, 4... 인 짝수인 요소이므로 for 문을 증감식을 2 씩 커지게 하여 실질적인 반복문의 단계수를 줄였습니다.

순수 함수로 작성을 하기 위해 전개연산자를 이용한 얕은복사를 해줬습니다.

## 분석
시간 복잡도는 자바스크립트 내장 메서드 sort를 사용하였으므로 `O(NlogN)` 입니다.
공간 복잡도는 순수 함수 작성을 배제하면 sort 메서드는 배열 그 자체를 정렬시키므로 `O(1)` 입니다.

## 추가 학습
1. 자바스크립트 내장 메서드를 사용하지 않는다면 어떤 식으로 풀어볼 수 있는지 생각해보기.
2. 시간복잡도 `O(N)` 의 풀이는 절대적으로 불가능한지 생각해보기.